### PR TITLE
fix: align comparison canonical URLs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 command = "pnpm build"
 publish = "build/client"
 
+# Prerendered pages are directory URLs, so keep their canonical trailing slashes.
+[build.processing.html]
+pretty_urls = true
+
 [[redirects]]
 from = "/playlist/*"
 to = "/__spa-fallback.html"

--- a/public/404.html
+++ b/public/404.html
@@ -18,7 +18,7 @@
       <p>404</p>
       <h1>Page not found</h1>
       <p>The page may have moved, or the address may be incomplete.</p>
-      <a href="/compare">Browse playlist tool comparisons</a>
+      <a href="/compare/">Browse playlist tool comparisons</a>
     </main>
   </body>
 </html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://ytpr.netlify.app/</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-ytpla</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-youtube-playlist-analyzer</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-playlistlength-app</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-youtubeplaylistlength-org</loc></url>
-  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-tunepocket</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-ytpla/</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-youtube-playlist-analyzer/</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-playlistlength-app/</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-youtubeplaylistlength-org/</loc></url>
+  <url><loc>https://ytpr.netlify.app/compare/yt-playlist-report-vs-tunepocket/</loc></url>
 </urlset>

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,10 +1,24 @@
 import type { Config } from "@react-router/dev/config";
-import { comparisonPath, comparisons } from "./src/content/comparisons";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "./src/content/comparisons";
+
+const prerenderPath = (canonicalPath: string) => canonicalPath.slice(0, -1);
 
 export default {
   appDirectory: "src",
   ssr: false,
   // Keep the root splat from short-circuiting lazy discovery during hydration.
   routeDiscovery: { mode: "initial" },
-  prerender: ["/", "/compare", ...comparisons.map(comparisonPath)],
+  // Router 7.18 prerenders route-manifest paths, while Netlify serves the
+  // generated directories at their canonical trailing-slash URLs.
+  prerender: [
+    "/",
+    prerenderPath(COMPARISON_HUB_PATH),
+    ...comparisons.map((comparison) =>
+      prerenderPath(comparisonPath(comparison))
+    ),
+  ],
 } satisfies Config;

--- a/scripts/verify-seo-build.mjs
+++ b/scripts/verify-seo-build.mjs
@@ -11,6 +11,9 @@ const assert = (condition, message) => {
   }
 };
 
+const SITE_URL = "https://ytpr.netlify.app";
+const COMPARISON_HUB_URL = `${SITE_URL}/compare/`;
+
 const comparisonSlugs = [
   "yt-playlist-report-vs-ytpla",
   "yt-playlist-report-vs-youtube-playlist-analyzer",
@@ -18,6 +21,19 @@ const comparisonSlugs = [
   "yt-playlist-report-vs-youtubeplaylistlength-org",
   "yt-playlist-report-vs-tunepocket",
 ];
+const comparisonUrls = comparisonSlugs.map(
+  (slug) => `${COMPARISON_HUB_URL}${slug}/`
+);
+const expectedSitemapUrls = [`${SITE_URL}/`, COMPARISON_HUB_URL, ...comparisonUrls];
+
+const canonicalUrl = (html) =>
+  html.match(/<link rel="canonical" href="([^"]+)"/)?.[1];
+const openGraphUrl = (html) =>
+  html.match(/<meta property="og:url" content="([^"]+)"/)?.[1];
+const structuredData = (html) =>
+  [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)].map(
+    ([, json]) => JSON.parse(json)
+  );
 
 const homepage = readOutput("index.html");
 assert(
@@ -25,19 +41,41 @@ assert(
   "Homepage must contain the stable playlist calculator H1"
 );
 assert(
-  homepage.includes('<link rel="canonical" href="https://ytpr.netlify.app/"'),
+  canonicalUrl(homepage) === `${SITE_URL}/`,
   "Homepage must include its canonical URL"
 );
 
 const hub = readOutput("compare", "index.html");
 assert(hub.match(/<h1/g)?.length === 1, "Comparison hub must have exactly one H1");
-assert(hub.includes('"@type":"CollectionPage"'), "Comparison hub must include CollectionPage JSON-LD");
+assert(canonicalUrl(hub) === COMPARISON_HUB_URL, "Comparison hub must self-canonicalize to its trailing-slash URL");
+assert(openGraphUrl(hub) === COMPARISON_HUB_URL, "Comparison hub Open Graph URL must match its canonical URL");
+const hubStructuredData = structuredData(hub).find(
+  (data) => data["@type"] === "CollectionPage"
+);
+assert(hubStructuredData, "Comparison hub must include CollectionPage JSON-LD");
+assert(hubStructuredData.url === COMPARISON_HUB_URL, "Comparison hub structured-data URL must match its canonical URL");
+assert(
+  JSON.stringify(hubStructuredData.mainEntity.itemListElement.map(({ url }) => url)) ===
+    JSON.stringify(comparisonUrls),
+  "Comparison hub structured data must list every canonical comparison URL"
+);
 
-for (const slug of comparisonSlugs) {
+for (const [index, slug] of comparisonSlugs.entries()) {
   const html = readOutput("compare", slug, "index.html");
+  const expectedUrl = comparisonUrls[index];
   assert(html.match(/<h1/g)?.length === 1, `${slug} must have exactly one H1`);
-  assert(html.includes(`<link rel="canonical" href="https://ytpr.netlify.app/compare/${slug}"`), `${slug} must have a canonical URL`);
-  assert(html.includes('"@type":"BreadcrumbList"'), `${slug} must include breadcrumb JSON-LD`);
+  assert(canonicalUrl(html) === expectedUrl, `${slug} must self-canonicalize to its trailing-slash URL`);
+  assert(openGraphUrl(html) === expectedUrl, `${slug} Open Graph URL must match its canonical URL`);
+  const data = structuredData(html);
+  const webPage = data.find((item) => item["@type"] === "WebPage");
+  const breadcrumbs = data.find((item) => item["@type"] === "BreadcrumbList");
+  assert(webPage?.url === expectedUrl, `${slug} WebPage structured-data URL must match its canonical URL`);
+  assert(breadcrumbs, `${slug} must include breadcrumb JSON-LD`);
+  assert(
+    breadcrumbs.itemListElement[1]?.item === COMPARISON_HUB_URL &&
+      breadcrumbs.itemListElement[2]?.item === expectedUrl,
+    `${slug} breadcrumb URLs must use canonical trailing-slash URLs`
+  );
   assert(html.includes("Sources and methodology"), `${slug} must include visible sources`);
   assert(html.includes("Compare all tools"), `${slug} must include comparison footer navigation`);
 }
@@ -45,9 +83,22 @@ for (const slug of comparisonSlugs) {
 const robots = readOutput("robots.txt");
 const sitemap = readOutput("sitemap.xml");
 const notFound = readOutput("404.html");
+const sitemapUrls = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+  ([, url]) => url
+);
 assert(robots.includes("Sitemap: https://ytpr.netlify.app/sitemap.xml"), "robots.txt must declare the sitemap");
 assert(!sitemap.includes("/playlist/"), "Generated playlist reports must not appear in the sitemap");
-assert(comparisonSlugs.every((slug) => sitemap.includes(slug)), "Sitemap must include every comparison page");
+assert(sitemapUrls.length === 7, "Sitemap must contain exactly seven URLs");
+assert(
+  JSON.stringify(sitemapUrls) === JSON.stringify(expectedSitemapUrls),
+  "Sitemap must contain only the homepage and canonical comparison URLs"
+);
+assert(
+  sitemapUrls
+    .filter((url) => url.startsWith(COMPARISON_HUB_URL))
+    .every((url) => url.endsWith("/")),
+  "Sitemap must not contain slashless comparison URLs"
+);
 assert(notFound.includes('content="noindex, follow"'), "404 page must be excluded from search results");
 
 console.log(`Verified homepage, comparison hub, ${comparisonSlugs.length} comparison pages, crawl files, and 404 response document.`);

--- a/src/components/Analytics.test.tsx
+++ b/src/components/Analytics.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router";
 import { RouterProvider } from "react-router/dom";
 import * as Counterscale from "@counterscale/tracker";
+import { comparisonPath, comparisons } from "@/content/comparisons";
 import Analytics from "./Analytics";
 
 vi.mock("@counterscale/tracker", () => ({
@@ -69,15 +70,16 @@ describe("Analytics", () => {
   });
 
   it("tracks comparison pages as ordinary pageviews", async () => {
+    const path = comparisonPath(comparisons[0]);
     const router = createMemoryRouter(routes, {
-      initialEntries: ["/compare/yt-playlist-report-vs-ytpla"],
+      initialEntries: [path],
     });
 
     render(<RouterProvider router={router} />);
 
     await waitFor(() => {
       expect(Counterscale.trackPageview).toHaveBeenCalledWith({
-        url: "/compare/yt-playlist-report-vs-ytpla",
+        url: path,
       });
     });
   });

--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter } from "react-router";
-import { comparisons } from "@/content/comparisons";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "@/content/comparisons";
 import Footer from "./Footer";
 
 afterEach(cleanup);
@@ -16,7 +20,7 @@ describe("Footer", () => {
 
     expect(
       screen.getByRole("link", { name: "Compare all tools" }).getAttribute("href")
-    ).toBe("/compare");
+    ).toBe(COMPARISON_HUB_PATH);
 
     for (const comparison of comparisons) {
       expect(
@@ -25,7 +29,7 @@ describe("Footer", () => {
             name: `YT Playlist Report vs ${comparison.competitorName}`,
           })
           .getAttribute("href")
-      ).toBe(`/compare/${comparison.slug}`);
+      ).toBe(comparisonPath(comparison));
     }
   });
 });

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,9 @@
 import { githubIcon, xIcon } from "@/assets";
-import { comparisonPath, comparisons } from "@/content/comparisons";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "@/content/comparisons";
 import { ArrowUpRight } from "lucide-react";
 import { Link } from "react-router";
 
@@ -30,7 +34,7 @@ const Footer = () => {
             </h2>
             <ul className="mt-5 space-y-3">
               <li>
-                <Link to="/compare" className="font-bold text-white hover:text-red-400">
+                <Link to={COMPARISON_HUB_PATH} className="font-bold text-white hover:text-red-400">
                   Compare all tools
                 </Link>
               </li>

--- a/src/content/comparisons.ts
+++ b/src/content/comparisons.ts
@@ -287,5 +287,7 @@ export const comparisonBySlug = new Map(
   comparisons.map((comparison) => [comparison.slug, comparison])
 );
 
+export const COMPARISON_HUB_PATH = "/compare/";
+
 export const comparisonPath = (comparison: Comparison) =>
-  `/compare/${comparison.slug}`;
+  `${COMPARISON_HUB_PATH}${comparison.slug}/`;

--- a/src/pages/Compare.test.tsx
+++ b/src/pages/Compare.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { createMemoryRouter, RouterProvider } from "react-router";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "@/content/comparisons";
 import Compare from "./Compare";
 import CompareIndex from "./CompareIndex";
 
@@ -10,7 +15,7 @@ describe("comparison pages", () => {
   it("presents all five alternatives and recommends YT Playlist Report on the hub", async () => {
     const router = createMemoryRouter(
       [{ path: "/compare", element: <CompareIndex /> }],
-      { initialEntries: ["/compare"] }
+      { initialEntries: [COMPARISON_HUB_PATH] }
     );
 
     render(<RouterProvider router={router} />);
@@ -26,9 +31,10 @@ describe("comparison pages", () => {
   });
 
   it("renders a complete, accessible competitor comparison", async () => {
+    const comparison = comparisons[0];
     const router = createMemoryRouter(
       [{ path: "/compare/:comparisonSlug", element: <Compare /> }],
-      { initialEntries: ["/compare/yt-playlist-report-vs-ytpla"] }
+      { initialEntries: [comparisonPath(comparison)] }
     );
 
     const { container } = render(<RouterProvider router={router} />);
@@ -47,6 +53,14 @@ describe("comparison pages", () => {
     expect(screen.getByRole("heading", { name: /sources and methodology/i })).toBeTruthy();
     expect(screen.getAllByRole("link", { name: /analyze a playlist free/i })).toHaveLength(2);
     expect(screen.getAllByTestId("related-comparison")).toHaveLength(2);
+    expect(
+      screen.getByRole("link", { name: "Comparisons" }).getAttribute("href")
+    ).toBe(COMPARISON_HUB_PATH);
+    expect(
+      screen
+        .getAllByTestId("related-comparison")
+        .every((link) => link.getAttribute("href")?.endsWith("/"))
+    ).toBe(true);
   });
 
   it("returns a normal not-found response for an unknown comparison", async () => {

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -3,20 +3,23 @@ import { Link, useParams, type MetaFunction } from "react-router";
 import JsonLd from "@/components/JsonLd";
 import PageShell from "@/components/PageShell";
 import {
+  COMPARISON_HUB_PATH,
   comparisonBySlug,
   comparisonPath,
   comparisons,
 } from "@/content/comparisons";
 import { pageMeta, SITE_NAME, SITE_URL } from "@/lib/site";
 
-export const meta: MetaFunction = ({ params }) => {
-  const comparison = comparisonBySlug.get(params.comparisonSlug ?? "");
+export const getCompareMeta = (comparisonSlug = "") => {
+  const comparison = comparisonBySlug.get(comparisonSlug);
 
   if (!comparison) {
     return pageMeta({
       title: `Comparison Not Found | ${SITE_NAME}`,
       description: "This playlist tool comparison could not be found.",
-      pathname: `/compare/${params.comparisonSlug ?? ""}`,
+      pathname: comparisonSlug
+        ? `${COMPARISON_HUB_PATH}${comparisonSlug}/`
+        : COMPARISON_HUB_PATH,
       robots: "noindex, follow",
     });
   }
@@ -27,6 +30,9 @@ export const meta: MetaFunction = ({ params }) => {
     pathname: comparisonPath(comparison),
   });
 };
+
+export const meta: MetaFunction = ({ params }) =>
+  getCompareMeta(params.comparisonSlug);
 
 const Compare = () => {
   const { comparisonSlug = "" } = useParams();
@@ -45,7 +51,7 @@ const Compare = () => {
           <p className="mt-4 text-lg text-neutral-600">
             The comparison may have moved, or the address may be incomplete.
           </p>
-          <Link to="/compare" className="mt-7 font-bold text-red-700 underline">
+          <Link to={COMPARISON_HUB_PATH} className="mt-7 font-bold text-red-700 underline">
             Browse all comparisons
           </Link>
         </main>
@@ -79,7 +85,7 @@ const Compare = () => {
           "@type": "ListItem",
           position: 2,
           name: "Comparisons",
-          item: `${SITE_URL}/compare`,
+          item: `${SITE_URL}${COMPARISON_HUB_PATH}`,
         },
         {
           "@type": "ListItem",
@@ -104,7 +110,7 @@ const Compare = () => {
                 <ol className="flex flex-wrap items-center gap-2">
                   <li><Link to="/" className="hover:text-red-700">Home</Link></li>
                   <li aria-hidden="true">/</li>
-                  <li><Link to="/compare" className="hover:text-red-700">Comparisons</Link></li>
+                  <li><Link to={COMPARISON_HUB_PATH} className="hover:text-red-700">Comparisons</Link></li>
                   <li aria-hidden="true">/</li>
                   <li aria-current="page">{comparison.competitorName}</li>
                 </ol>

--- a/src/pages/CompareIndex.tsx
+++ b/src/pages/CompareIndex.tsx
@@ -2,15 +2,21 @@ import { ArrowRight, Check, Scale } from "lucide-react";
 import { Link, type MetaFunction } from "react-router";
 import JsonLd from "@/components/JsonLd";
 import PageShell from "@/components/PageShell";
-import { comparisonPath, comparisons } from "@/content/comparisons";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "@/content/comparisons";
 import { pageMeta, SITE_NAME, SITE_URL } from "@/lib/site";
 
 const title = "Best YouTube Playlist Analyzers Compared (2026)";
 const description =
   "Compare leading YouTube playlist length calculators and analyzers for duration, search, exports, planning, privacy, detailed metrics, and sharing.";
 
-export const meta: MetaFunction = () =>
-  pageMeta({ title, description, pathname: "/compare" });
+export const getCompareIndexMeta = () =>
+  pageMeta({ title, description, pathname: COMPARISON_HUB_PATH });
+
+export const meta: MetaFunction = getCompareIndexMeta;
 
 const CompareIndex = () => {
   const structuredData = {
@@ -18,7 +24,7 @@ const CompareIndex = () => {
     "@type": "CollectionPage",
     name: title,
     description,
-    url: `${SITE_URL}/compare`,
+    url: `${SITE_URL}${COMPARISON_HUB_PATH}`,
     mainEntity: {
       "@type": "ItemList",
       itemListElement: comparisons.map((comparison, index) => ({

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { Link, type MetaFunction } from "react-router";
 import PageShell from "@/components/PageShell";
+import { COMPARISON_HUB_PATH } from "@/content/comparisons";
 import { pageMeta, SITE_NAME } from "@/lib/site";
 
 export const getNotFoundMeta = () =>
@@ -25,7 +26,7 @@ function NotFound() {
         <p className="mt-4 text-lg text-neutral-600">
           The page may have moved, or the address may be incomplete.
         </p>
-        <Link to="/compare" className="mt-7 font-bold text-red-700 underline">
+        <Link to={COMPARISON_HUB_PATH} className="mt-7 font-bold text-red-700 underline">
           Browse playlist tool comparisons
         </Link>
       </main>

--- a/src/pages/seo.test.ts
+++ b/src/pages/seo.test.ts
@@ -1,11 +1,36 @@
 import { describe, expect, it } from "vitest";
+import {
+  COMPARISON_HUB_PATH,
+  comparisonPath,
+  comparisons,
+} from "@/content/comparisons";
+import { SITE_URL } from "@/lib/site";
+import { getCompareMeta } from "./Compare";
+import { getCompareIndexMeta } from "./CompareIndex";
 import { getLandingMeta } from "./Landing";
 import { getReportMeta } from "./Report";
 
+type MetaDescriptors = ReturnType<typeof getLandingMeta>;
+
 const findMeta = (
-  descriptors: ReturnType<typeof getLandingMeta>,
+  descriptors: MetaDescriptors,
   name: string
 ) => descriptors.find((descriptor) => "name" in descriptor && descriptor.name === name);
+
+const findProperty = (descriptors: MetaDescriptors, property: string) =>
+  descriptors.find(
+    (descriptor) =>
+      "property" in descriptor && descriptor.property === property
+  );
+
+const findCanonical = (descriptors: MetaDescriptors) =>
+  descriptors.find(
+    (descriptor) =>
+      "tagName" in descriptor &&
+      descriptor.tagName === "link" &&
+      "rel" in descriptor &&
+      descriptor.rel === "canonical"
+  );
 
 describe("route metadata", () => {
   it("targets playlist calculator and analyzer searches on the homepage", () => {
@@ -26,6 +51,41 @@ describe("route metadata", () => {
     expect(findMeta(getReportMeta(), "robots")).toEqual({
       name: "robots",
       content: "noindex, follow",
+    });
+  });
+
+  it("uses trailing-slash paths for the comparison hub and articles", () => {
+    expect(COMPARISON_HUB_PATH).toBe("/compare/");
+
+    for (const comparison of comparisons) {
+      expect(comparisonPath(comparison)).toBe(
+        `/compare/${comparison.slug}/`
+      );
+    }
+  });
+
+  it("aligns comparison canonical and Open Graph URLs", () => {
+    const hubUrl = `${SITE_URL}${COMPARISON_HUB_PATH}`;
+    const comparison = comparisons[0];
+    const comparisonUrl = `${SITE_URL}${comparisonPath(comparison)}`;
+
+    expect(findCanonical(getCompareIndexMeta())).toEqual({
+      tagName: "link",
+      rel: "canonical",
+      href: hubUrl,
+    });
+    expect(findProperty(getCompareIndexMeta(), "og:url")).toEqual({
+      property: "og:url",
+      content: hubUrl,
+    });
+    expect(findCanonical(getCompareMeta(comparison.slug))).toEqual({
+      tagName: "link",
+      rel: "canonical",
+      href: comparisonUrl,
+    });
+    expect(findProperty(getCompareMeta(comparison.slug), "og:url")).toEqual({
+      property: "og:url",
+      content: comparisonUrl,
     });
   });
 });


### PR DESCRIPTION
Aligns comparison canonical metadata, internal links, structured data, prerendering, and the sitemap on trailing-slash URLs. Adds focused unit, production-build, and browser verification.