### PR TITLE
Add dynamic GitHub stars indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ The app supports a patched, password-protected [Counterscale v3.4.1](https://git
    ```
 3. Rebuild and deploy the app.
 
+### GitHub stars indicator
+
+The header loads the repository's star count from `/api/github-stars`. The
+Netlify function fetches the count server-side and returns only
+`{ "count": number }`. You can configure the optional `GITHUB_TOKEN` Netlify
+environment variable to increase the GitHub API rate limit; the route also
+works without it. Successful responses are cached for 24 hours and may remain
+stale for one additional hour while the cache refreshes in the background.
+
 Normal navigation is recorded as a pageview. A playlist path such as `/playlist/PLabc123` is recorded only after its complete report loads successfully, once per completed report view. Analytics failures never block report generation.
 
 The versioned [Counterscale patch](analytics/counterscale/counterscale-v3.4.1.patch) adds the playlist leaderboard, exact-origin ingestion controls, bot suppression, and removes the R2 binding and archive cron.

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,11 @@ publish = "build/client"
 pretty_urls = true
 
 [[redirects]]
+from = "/api/github-stars"
+to = "/.netlify/functions/github-stars"
+status = 200
+
+[[redirects]]
 from = "/playlist/*"
 to = "/__spa-fallback.html"
 status = 200

--- a/netlify/functions/github-stars.ts
+++ b/netlify/functions/github-stars.ts
@@ -1,0 +1,85 @@
+const REPOSITORY_OWNER = "buneeIsSlo";
+const REPOSITORY_NAME = "yt-playlist-report";
+const GITHUB_TIMEOUT_MS = 5_000;
+const NETLIFY_CACHE_CONTROL =
+  "public, durable, s-maxage=86400, stale-while-revalidate=3600";
+
+export interface FunctionRequest {
+  httpMethod?: string;
+}
+
+export interface FunctionResponse {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface GitHubRepositoryResponse {
+  stargazers_count?: unknown;
+}
+
+const successResponse = (count: number): FunctionResponse => ({
+  statusCode: 200,
+  headers: {
+    "Content-Type": "application/json",
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    "Netlify-CDN-Cache-Control": NETLIFY_CACHE_CONTROL,
+  },
+  body: JSON.stringify({ count }),
+});
+
+const errorResponse = (
+  statusCode: number,
+  headers: Record<string, string> = {}
+): FunctionResponse => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    ...headers,
+  },
+  body: JSON.stringify({}),
+});
+
+export async function handler(
+  request: FunctionRequest = {}
+): Promise<FunctionResponse> {
+  if (request.httpMethod && request.httpMethod !== "GET") {
+    return errorResponse(405, { Allow: "GET" });
+  }
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  const token = process.env.GITHUB_TOKEN?.trim();
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${REPOSITORY_OWNER}/${REPOSITORY_NAME}`,
+      {
+        headers,
+        signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+      }
+    );
+
+    if (!response.ok) {
+      return errorResponse(502);
+    }
+
+    const repository = (await response.json()) as GitHubRepositoryResponse;
+    const count = repository.stargazers_count;
+
+    if (typeof count !== "number" || !Number.isInteger(count) || count < 0) {
+      return errorResponse(502);
+    }
+
+    return successResponse(count);
+  } catch {
+    return errorResponse(502);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "react-router dev",
-    "build": "tsc && react-router build",
+    "build": "tsc && tsc -p tsconfig.server.json && react-router build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview --outDir build/client",
     "test": "vitest run",

--- a/src/components/HeaderNav.test.tsx
+++ b/src/components/HeaderNav.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import HeaderNav from "./HeaderNav";
+
+const okResponse = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200 });
+
+describe("HeaderNav GitHub stars", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(okResponse({ count: 16 })))
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads and displays the star count on mount", async () => {
+    render(<HeaderNav />);
+
+    expect(await screen.findByText("16")).toBeTruthy();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/github-stars",
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("does not render the former hardcoded count while loading", () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => undefined)));
+
+    render(<HeaderNav />);
+
+    expect(screen.queryByText("8")).toBeNull();
+  });
+
+  it("hides the count when the route fails", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("offline"))));
+
+    render(<HeaderNav />);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(screen.queryByText("16")).toBeNull();
+  });
+
+  it("hides the count when the route returns an invalid payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(okResponse({ count: "16" })))
+    );
+
+    render(<HeaderNav />);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    expect(screen.queryByText("16")).toBeNull();
+  });
+
+  it("aborts the request when the header unmounts", () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => undefined)));
+
+    const { unmount } = render(<HeaderNav />);
+    const options = vi.mocked(fetch).mock.calls[0][1];
+
+    expect(options?.signal?.aborted).toBe(false);
+    unmount();
+    expect(options?.signal?.aborted).toBe(true);
+  });
+});

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -1,8 +1,43 @@
 import { githubIcon, logoIcon } from "@/assets";
 import { Button } from "./ui/button";
 import { StarIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 
 const HeaderNav = () => {
+  const [githubStars, setGithubStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    const loadGithubStars = async () => {
+      try {
+        const response = await fetch("/api/github-stars", {
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          return;
+        }
+
+        const payload = (await response.json()) as { count?: unknown };
+
+        if (
+          typeof payload.count === "number" &&
+          Number.isInteger(payload.count) &&
+          payload.count >= 0
+        ) {
+          setGithubStars(payload.count);
+        }
+      } catch {
+        // The GitHub link remains usable when the optional count is unavailable.
+      }
+    };
+
+    void loadGithubStars();
+
+    return () => controller.abort();
+  }, []);
+
   return (
     <header className="w-full backdrop-blur-lg bg-red-100/5 border-b py-2 md:py-2.5 sticky top-0 left-0 z-10">
       <div className="container flex justify-between items-center">
@@ -26,7 +61,9 @@ const HeaderNav = () => {
             >
               <span className="border-l p-2 flex gap-1 items-center">
                 <StarIcon className="w-4 h-4  stroke-yellow-400 fill-yellow-400" />
-                <span className="font-semibold">8</span>
+                {githubStars !== null ? (
+                  <span className="font-semibold">{githubStars}</span>
+                ) : null}
               </span>
               <span className="px-1 md:p-2 flex flex-row-reverse items-center gap-1">
                 Star on GitHub

--- a/tests/github-stars.test.ts
+++ b/tests/github-stars.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handler } from "../netlify/functions/github-stars";
+
+const githubResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+describe("github-stars function", () => {
+  beforeEach(() => {
+    vi.stubEnv("GITHUB_TOKEN", "");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(githubResponse({ stargazers_count: 16 }))
+      )
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns only the numeric star count", async () => {
+    const response = await handler({ httpMethod: "GET" });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toEqual({ count: 16 });
+  });
+
+  it("sets a 24-hour durable CDN cache only on success", async () => {
+    const response = await handler({ httpMethod: "GET" });
+
+    expect(response.headers["Netlify-CDN-Cache-Control"]).toBe(
+      "public, durable, s-maxage=86400, stale-while-revalidate=3600"
+    );
+    expect(response.headers["Cache-Control"]).toBe(
+      "public, max-age=0, must-revalidate"
+    );
+  });
+
+  it("works without a GitHub token and applies an upstream timeout", async () => {
+    await handler({ httpMethod: "GET" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/repos/buneeIsSlo/yt-playlist-report",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({ Authorization: expect.anything() }),
+        signal: expect.any(AbortSignal),
+      })
+    );
+  });
+
+  it("uses the optional GitHub token when configured", async () => {
+    vi.stubEnv("GITHUB_TOKEN", "secret-token");
+
+    await handler({ httpMethod: "GET" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret-token",
+        }),
+      })
+    );
+  });
+
+  it("returns an uncached server error for upstream failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(githubResponse({}, 503)))
+    );
+
+    const response = await handler({ httpMethod: "GET" });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.headers["Cache-Control"]).toBe("no-store");
+    expect(response.headers).not.toHaveProperty("Netlify-CDN-Cache-Control");
+  });
+
+  it("returns an uncached server error for malformed data", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(githubResponse({ stargazers_count: "16" }))
+      )
+    );
+
+    const response = await handler({ httpMethod: "GET" });
+
+    expect(response.statusCode).toBe(502);
+    expect(response.headers["Cache-Control"]).toBe("no-store");
+  });
+
+  it("rejects methods other than GET without contacting GitHub", async () => {
+    const response = await handler({ httpMethod: "POST" });
+
+    expect(response.statusCode).toBe(405);
+    expect(response.headers.Allow).toBe("GET");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts", "netlify/functions"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,31 @@
 import path from "path"
 import { reactRouter } from "@react-router/dev/vite"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
+import { handler } from "./netlify/functions/github-stars"
+
+const localGithubStarsApi = (): Plugin => ({
+  name: "local-github-stars-api",
+  configureServer(server) {
+    server.middlewares.use(async (request, response, next) => {
+      if (request.url?.split("?", 1)[0] !== "/api/github-stars") {
+        next()
+        return
+      }
+
+      const result = await handler({ httpMethod: request.method })
+      response.statusCode = result.statusCode
+
+      for (const [name, value] of Object.entries(result.headers)) {
+        response.setHeader(name, value)
+      }
+
+      response.end(result.body)
+    })
+  },
+})
 
 export default defineConfig({
-  plugins: [reactRouter()],
+  plugins: [localGithubStarsApi(), reactRouter()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
The header's GitHub star count was hardcoded, so it became stale as the repository changed. This adds a Netlify function that returns the current count, caches successful responses for 24 hours, and keeps errors uncached.

The React header fetches the route on mount and hides the optional number if the route fails. Vite serves the same handler during local development, and the production Netlify rewrite is defined before the SPA/404 routes.

Validation:

- `pnpm test` — 33 tests passed
- `pnpm lint`
- `pnpm build`
- `pnpm test:seo`
- Local API returned `200 {"count":16}` with the expected cache headers
- Browser verified the dynamic count with no console errors
